### PR TITLE
Update to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 jdk:
-    - openjdk7
     - oraclejdk8
     - oraclejdk9
+    - oraclejdk11
+    - openjdk10
+    - openjdk11

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 java-otp is a library for generating one-time passwords using the [HOTP (RFC 4226)](https://tools.ietf.org/html/rfc4226) or [TOTP (RFC 6238)](https://tools.ietf.org/html/rfc6238) standards in Java.
 
+## System requirements
+
+java-otp works with Java 8 or newer. If you need support for versions of Java older than Java 8, you may try using java-otp v0.1 (although it is no longer supported).
+
 ## Usage
 
 To demonstrate generating one-time passwords, we'll focus on the TOTP algorithm. To create a TOTP generator with a default password length (6 digits), time step (30 seconds), and HMAC algorithm (HMAC-SHA1):

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ final Key key;
 {
     final KeyGenerator keyGenerator = KeyGenerator.getInstance(totp.getAlgorithm());
 
-    // HMAC-SHA1 and HMAC-SHA256 prefer 64-byte (512-bit) keys; HMAC-SHA512 prefers 128-byte (1024-bit) keys
+    // SHA-1 and SHA-256 prefer 64-byte (512-bit) keys; SHA512 prefers 128-byte (1024-bit) keys
     keyGenerator.init(512);
 
     key = keyGenerator.generateKey();
@@ -31,8 +31,8 @@ final Key key;
 Armed with a secret key, we can deterministically generate one-time passwords for any timestamp:
 
 ```java
-final Date now = new Date();
-final Date later = new Date(now.getTime() + totp.getTimeStep(TimeUnit.MILLISECONDS));
+final Instant now = Instant.now();
+final Instant later = now.plus(totp.getTimeStep());
 
 System.out.format("Current password: %06d\n", totp.generateOneTimePassword(key, now));
 System.out.format("Future password:  %06d\n", totp.generateOneTimePassword(key, later));

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,16 +49,16 @@
     
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>pl.pragmatists</groupId>
-            <artifactId>JUnitParams</artifactId>
-            <version>1.1.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/eatthepath/otp/ExampleApp.java
+++ b/src/test/java/com/eatthepath/otp/ExampleApp.java
@@ -24,8 +24,7 @@ import javax.crypto.KeyGenerator;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
+import java.time.Instant;
 
 public class ExampleApp {
     public static void main(final String[] args) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -41,8 +40,8 @@ public class ExampleApp {
             key = keyGenerator.generateKey();
         }
 
-        final Date now = new Date();
-        final Date later = new Date(now.getTime() + totp.getTimeStep(TimeUnit.MILLISECONDS));
+        final Instant now = Instant.now();
+        final Instant later = now.plus(totp.getTimeStep());
 
         System.out.format("Current password: %06d\n", totp.generateOneTimePassword(key, now));
         System.out.format("Future password:  %06d\n", totp.generateOneTimePassword(key, later));

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -29,8 +29,8 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,13 +58,12 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
 
     @Test
     void testGetTimeStep() throws NoSuchAlgorithmException {
-        final long timeStepSeconds = 97;
+        final Duration timeStep = Duration.ofSeconds(97);
 
         final TimeBasedOneTimePasswordGenerator totp =
-                new TimeBasedOneTimePasswordGenerator(timeStepSeconds, TimeUnit.SECONDS);
+                new TimeBasedOneTimePasswordGenerator(timeStep);
 
-        assertEquals(timeStepSeconds, totp.getTimeStep(TimeUnit.SECONDS));
-        assertEquals(timeStepSeconds * 1000, totp.getTimeStep(TimeUnit.MILLISECONDS));
+        assertEquals(timeStep, totp.getTimeStep());
     }
 
     /**
@@ -79,11 +78,11 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
     void testGenerateOneTimePassword(final String algorithm, final Key key, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
 
         final TimeBasedOneTimePasswordGenerator totp =
-                new TimeBasedOneTimePasswordGenerator(30, TimeUnit.SECONDS, 8, algorithm);
+                new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
 
-        final Date date = new Date(TimeUnit.SECONDS.toMillis(epochSeconds));
+        final Instant timestamp = Instant.ofEpochSecond(epochSeconds);
 
-        assertEquals(expectedOneTimePassword, totp.generateOneTimePassword(key, date));
+        assertEquals(expectedOneTimePassword, totp.generateOneTimePassword(key, timestamp));
     }
 
     static Stream<Arguments> totpTestVectorSource() {


### PR DESCRIPTION
This updates everything to Java 8. The two main changes are:

1. We can now use JUnit 5.
2. We can now use JSR-310 temporal types (particularly `Instant`).