### PR TITLE
Add benchmarks and optimize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,18 +61,101 @@
             <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.21</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.21</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>
         <plugins>
+            <!-- Add benchmarks as a source directory -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/benchmark/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.openjdk.jmh</groupId>
+                                    <artifactId>jmh-generator-annprocess</artifactId>
+                                    <version>1.21</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/benchmark.xml</descriptor>
+                    </descriptors>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <attach>true</attach>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/assembly/benchmark.xml
+++ b/src/assembly/benchmark.xml
@@ -1,0 +1,26 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>benchmark</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/benchmark/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorBenchmark.java
+++ b/src/benchmark/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorBenchmark.java
@@ -1,0 +1,35 @@
+package com.eatthepath.otp;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import javax.crypto.KeyGenerator;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+
+@State(Scope.Thread)
+public class HmacOneTimePasswordGeneratorBenchmark {
+
+    private HmacOneTimePasswordGenerator hotp;
+    private Key key;
+
+    private int counter = 0;
+
+    @Setup
+    public void setUp() throws NoSuchAlgorithmException {
+        this.hotp = new HmacOneTimePasswordGenerator();
+
+        final KeyGenerator keyGenerator = KeyGenerator.getInstance(this.hotp.getAlgorithm());
+        keyGenerator.init(512);
+
+        this.key = keyGenerator.generateKey();
+    }
+
+    @Benchmark
+    public int benchmarkGenerateOneTimePassword() throws InvalidKeyException {
+        return this.hotp.generateOneTimePassword(this.key, this.counter++);
+    }
+}

--- a/src/main/java/com/eatthepath/otp/HmacOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/HmacOneTimePasswordGenerator.java
@@ -42,6 +42,8 @@ public class HmacOneTimePasswordGenerator {
 
     private final int modDivisor;
 
+    private final ThreadLocal<Mac> macThreadLocal;
+
     /**
      * The default length, in decimal digits, for one-time passwords.
      */
@@ -118,6 +120,16 @@ public class HmacOneTimePasswordGenerator {
         // Our purpose here is just to throw an exception immediately if the algorithm is bogus.
         Mac.getInstance(algorithm);
         this.algorithm = algorithm;
+
+        this.macThreadLocal = ThreadLocal.withInitial(() -> {
+            try {
+                return Mac.getInstance(algorithm);
+            } catch (final NoSuchAlgorithmException e) {
+                // This should never happen; we just checked to make sure we could instantiate a MAC with this
+                // algorithm, and if we made it this far, we know it worked.
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     /**
@@ -132,15 +144,8 @@ public class HmacOneTimePasswordGenerator {
      * @throws InvalidKeyException if the given key is inappropriate for initializing the {@link Mac} for this generator
      */
     public int generateOneTimePassword(final Key key, final long counter) throws InvalidKeyException {
-        final Mac mac;
-
-        try {
-            mac = Mac.getInstance(this.algorithm);
-            mac.init(key);
-        } catch (final NoSuchAlgorithmException e) {
-            // This should never happen since we verify that the algorithm is legit in the constructor.
-            throw new RuntimeException(e);
-        }
+        final Mac mac = this.macThreadLocal.get();
+        mac.init(key);
 
         final ByteBuffer buffer = ByteBuffer.allocate(8);
         buffer.putLong(0, counter);


### PR DESCRIPTION
This adds benchmarks, then does some gentle optimization. In particular, we now avoid re-instantiating a `Mac` on every call to `generateOneTimePassword`, which results in a throughput increase of about 50%.