### PR TITLE
Use synchronization instead of ThreadLocals for thread safety

### DIFF
--- a/src/benchmark/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorBenchmark.java
+++ b/src/benchmark/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorBenchmark.java
@@ -10,7 +10,7 @@ import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 
-@State(Scope.Thread)
+@State(Scope.Benchmark)
 public class HmacOneTimePasswordGeneratorBenchmark {
 
     private HmacOneTimePasswordGenerator hotp;

--- a/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
@@ -31,8 +31,7 @@ import java.time.Instant;
  * <p>Generates time-based one-time passwords (TOTP) as specified in
  * <a href="https://tools.ietf.org/html/rfc6238">RFC&nbsp;6238</a>.</p>
  *
- * <p>{@code TimeBasedOneTimePasswordGenerator} instances are thread-safe and may be shared and re-used across multiple
- * threads.</p>
+ * <p>{@code TimeBasedOneTimePasswordGenerator} instances are thread-safe and may be shared between threads.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */


### PR DESCRIPTION
The `ThreadLocal`-based approach introduced in 5e625e7 works, but I'm concerned that it's making things too complicated and introduces too much baggage for casual use cases. As an alternative, this approach just uses synchronization to manage access to stateful resources.

I like this approach because:

1. It maintains thread-safety.
2. The performance cost in single-threaded cases is negligible.
3. Callers can still create one HOTP/TOTP generator per thread if they're really concerned about throughput.