### PR TITLE
Generate one-time passwords as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Armed with a key, we can deterministically generate one-time passwords for any t
 final Instant now = Instant.now();
 final Instant later = now.plus(totp.getTimeStep());
 
-System.out.format("Current password: %06d\n", totp.generateOneTimePassword(key, now));
-System.out.format("Future password:  %06d\n", totp.generateOneTimePassword(key, later));
+System.out.println("Current password: " + totp.generateOneTimePasswordString(key, now));
+System.out.println("Future password:  " + totp.generateOneTimePasswordString(key, later));
 ```
 
 …which produces (for one randomly-generated key):

--- a/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
@@ -26,6 +26,7 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 
 /**
  * <p>Generates time-based one-time passwords (TOTP) as specified in
@@ -140,6 +141,38 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      */
     public int generateOneTimePassword(final Key key, final Instant timestamp) throws InvalidKeyException {
         return this.generateOneTimePassword(key, timestamp.toEpochMilli() / this.timeStep.toMillis());
+    }
+
+    /**
+     * Generates a one-time password using the given key and timestamp and formats it as a string with the system
+     * default locale.
+     *
+     * @param key the key to be used to generate the password
+     * @param timestamp the timestamp for which to generate the password
+     *
+     * @return a string representation of a one-time password
+     *
+     * @throws InvalidKeyException if the given key is inappropriate for initializing the {@link Mac} for this generator
+     *
+     * @see Locale#getDefault()
+     */
+    public String generateOneTimePasswordString(final Key key, final Instant timestamp) throws InvalidKeyException {
+        return this.generateOneTimePasswordString(key, timestamp, Locale.getDefault());
+    }
+
+    /**
+     * Generates a one-time password using the given key and timestamp and formats it as a string with the given locale.
+     *
+     * @param key the key to be used to generate the password
+     * @param timestamp the timestamp for which to generate the password
+     * @param locale the locale to apply during formatting
+     *
+     * @return a string representation of a one-time password
+     *
+     * @throws InvalidKeyException if the given key is inappropriate for initializing the {@link Mac} for this generator
+     */
+    public String generateOneTimePasswordString(final Key key, final Instant timestamp, final Locale locale) throws InvalidKeyException {
+        return this.formatOneTimePassword(this.generateOneTimePassword(key, timestamp), locale);
     }
 
     /**

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -49,8 +49,8 @@ THE SOFTWARE. -->
         <pre>final Instant now = Instant.now();
 final Instant later = now.plus(totp.getTimeStep());
 
-System.out.format("Current password: %06d\n", totp.generateOneTimePassword(key, now));
-System.out.format("Future password:  %06d\n", totp.generateOneTimePassword(key, later));</pre>
+System.out.println("Current password: " + totp.generateOneTimePasswordString(key, now));
+System.out.println("Future password:  " + totp.generateOneTimePasswordString(key, later));</pre>
 
         <h1>License and copyright</h1>
 

--- a/src/test/java/com/eatthepath/otp/ExampleApp.java
+++ b/src/test/java/com/eatthepath/otp/ExampleApp.java
@@ -44,7 +44,7 @@ public class ExampleApp {
         final Instant now = Instant.now();
         final Instant later = now.plus(totp.getTimeStep());
 
-        System.out.format("Current password: %06d\n", totp.generateOneTimePassword(key, now));
-        System.out.format("Future password:  %06d\n", totp.generateOneTimePassword(key, later));
+        System.out.println("Current password: " + totp.generateOneTimePasswordString(key, now));
+        System.out.println("Future password:  " + totp.generateOneTimePasswordString(key, later));
     }
 }

--- a/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
@@ -29,6 +29,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,12 +74,12 @@ public class HmacOneTimePasswordGeneratorTest {
      * <a href="https://tools.ietf.org/html/rfc4226#appendix-D">RFC&nbsp;4226, Appendix D</a>.
      */
     @ParameterizedTest
-    @MethodSource("hotpTestVectorSource")
+    @MethodSource("argumentsForTestGenerateOneTimePasswordHotp")
     void testGenerateOneTimePassword(final int counter, final int expectedOneTimePassword) throws Exception {
         assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePassword(HOTP_KEY, counter));
     }
 
-    static Stream<Arguments> hotpTestVectorSource() {
+    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordHotp() {
         return Stream.of(
                 arguments(0, 755224),
                 arguments(1, 287082),
@@ -90,6 +91,52 @@ public class HmacOneTimePasswordGeneratorTest {
                 arguments(7, 162583),
                 arguments(8, 399871),
                 arguments(9, 520489)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForTestGenerateOneTimePasswordStringHotp")
+    void testGenerateOneTimePasswordString(final int counter, final String expectedOneTimePassword) throws Exception {
+        Locale.setDefault(Locale.US);
+        assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePasswordString(HOTP_KEY, counter));
+    }
+
+    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringHotp() {
+        return Stream.of(
+                arguments(0, "755224"),
+                arguments(1, "287082"),
+                arguments(2, "359152"),
+                arguments(3, "969429"),
+                arguments(4, "338314"),
+                arguments(5, "254676"),
+                arguments(6, "287922"),
+                arguments(7, "162583"),
+                arguments(8, "399871"),
+                arguments(9, "520489")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForTestGenerateOneTimePasswordStringLocaleHotp")
+    void testGenerateOneTimePasswordStringLocale(final int counter, final Locale locale, final String expectedOneTimePassword) throws Exception {
+        Locale.setDefault(Locale.US);
+        assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePasswordString(HOTP_KEY, counter, locale));
+    }
+
+    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringLocaleHotp() {
+        final Locale locale = Locale.forLanguageTag("hi-IN");
+
+        return Stream.of(
+                arguments(0, locale, "७५५२२४"),
+                arguments(1, locale, "२८७०८२"),
+                arguments(2, locale, "३५९१५२"),
+                arguments(3, locale, "९६९४२९"),
+                arguments(4, locale, "३३८३१४"),
+                arguments(5, locale, "२५४६७६"),
+                arguments(6, locale, "२८७९२२"),
+                arguments(7, locale, "१६२५८३"),
+                arguments(8, locale, "३९९८७१"),
+                arguments(9, locale, "५२०४८९")
         );
     }
 

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -31,6 +31,7 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,8 +75,8 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
      * different keys are used for each of the various HMAC algorithms.
      */
     @ParameterizedTest
-    @MethodSource("totpTestVectorSource")
-    void testGenerateOneTimePassword(final String algorithm, final Key key, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
+    @MethodSource("argumentsForTestGenerateOneTimePasswordTotp")
+    void testGenerateOneTimePasswordTotp(final String algorithm, final Key key, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
 
         final TimeBasedOneTimePasswordGenerator totp =
                 new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
@@ -85,7 +86,7 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
         assertEquals(expectedOneTimePassword, totp.generateOneTimePassword(key, timestamp));
     }
 
-    static Stream<Arguments> totpTestVectorSource() {
+    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordTotp() {
         return Stream.of(
                 arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,            59L, 94287082),
                 arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111109L,  7081804),
@@ -105,6 +106,78 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
                 arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1234567890L, 93441116),
                 arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  2000000000L, 38618901),
                 arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY, 20000000000L, 47863826)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForTestGenerateOneTimePasswordStringTotp")
+    void testGenerateOneTimePasswordStringTotp(final String algorithm, final Key key, final long epochSeconds, final String expectedOneTimePassword) throws Exception {
+
+        final TimeBasedOneTimePasswordGenerator totp =
+                new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
+
+        final Instant timestamp = Instant.ofEpochSecond(epochSeconds);
+
+        assertEquals(expectedOneTimePassword, totp.generateOneTimePasswordString(key, timestamp));
+    }
+
+    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringTotp() {
+        return Stream.of(
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,            59L, "94287082"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111109L, "07081804"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111111L, "14050471"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1234567890L, "89005924"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    2000000000L, "69279037"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,   20000000000L, "65353130"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,          59L, "46119246"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111109L, "68084774"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111111L, "67062674"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1234567890L, "91819424"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  2000000000L, "90698825"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY, 20000000000L, "77737706"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,          59L, "90693936"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111109L, "25091201"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111111L, "99943326"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1234567890L, "93441116"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  2000000000L, "38618901"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY, 20000000000L, "47863826")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForTestGenerateOneTimePasswordStringLocaleTotp")
+    void testGenerateOneTimePasswordStringLocaleTotp(final String algorithm, final Key key, final long epochSeconds, final Locale locale, final String expectedOneTimePassword) throws Exception {
+
+        final TimeBasedOneTimePasswordGenerator totp =
+                new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
+
+        final Instant timestamp = Instant.ofEpochSecond(epochSeconds);
+
+        assertEquals(expectedOneTimePassword, totp.generateOneTimePasswordString(key, timestamp, locale));
+    }
+
+    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringLocaleTotp() {
+        final Locale locale = Locale.forLanguageTag("hi-IN");
+
+        return Stream.of(
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,            59L, locale, "९४२८७०८२"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111109L, locale, "०७०८१८०४"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111111L, locale, "१४०५०४७१"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1234567890L, locale, "८९००५९२४"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    2000000000L, locale, "६९२७९०३७"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,   20000000000L, locale, "६५३५३१३०"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,          59L, locale, "४६११९२४६"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111109L, locale, "६८०८४७७४"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111111L, locale, "६७०६२६७४"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1234567890L, locale, "९१८१९४२४"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  2000000000L, locale, "९०६९८८२५"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY, 20000000000L, locale, "७७७३७७०६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,          59L, locale, "९०६९३९३६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111109L, locale, "२५०९१२०१"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111111L, locale, "९९९४३३२६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1234567890L, locale, "९३४४१११६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  2000000000L, locale, "३८६१८९०१"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY, 20000000000L, locale, "४७८६३८२६")
         );
     }
 }


### PR DESCRIPTION
This pull request allows java-otp to generate one-time passwords as pre-formatted strings in addition to integers.

I've been hesitant to make this change for fear of starting down a slippery slope into prescribing how users manage security, but I think I'm convinced now that it's not over the line and that converting integers to strings is confusing to enough users that it's worth doing.