### PR TITLE
Set an automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.2.0</version>
                 <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.eatthepath.otp</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                     <excludes>
                         <exclude>**/.gitignore</exclude>
                     </excludes>


### PR DESCRIPTION
As requested in #15, this sets an automatic module name for the project, which lets us keep the target language level at 8 while producing the metadata needed for JPMS interoperability.

This closes #15.