### PR TITLE
Switch back to `ByteBuffer` when generating one-time passwords

### DIFF
--- a/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
@@ -79,6 +79,14 @@ public class HmacOneTimePasswordGeneratorTest {
         assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePassword(HOTP_KEY, counter));
     }
 
+    @Test
+    void testGenerateOneTimePasswordRepeated() throws Exception {
+        final HmacOneTimePasswordGenerator hotpGenerator = new HmacOneTimePasswordGenerator();
+
+        assertEquals(755224, hotpGenerator.generateOneTimePassword(HOTP_KEY, 0));
+        assertEquals(287082, hotpGenerator.generateOneTimePassword(HOTP_KEY, 1));
+    }
+
     private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordHotp() {
         return Stream.of(
                 arguments(0, 755224),


### PR DESCRIPTION
Previously, I [switched from using `ByteBuffer` to `byte[]`](d6a9c470f90a89fc15f1762cfe8cbd7b1b9571f9) in the interest of avoiding an allocation on every call to `generateOneTimePassword`. It turns out those were two orthogonal ideas, though, and we can keep the `ByteBuffer` and still avoid repeated allocations.

Switching back to a `ByteBuffer` makes things a lot more readable and ~actually gives us a very modest throughput boost, too~ has no statistically-significant effect on throughput.