### PR TITLE
Use `maven.compiler.release` to control build targets under Java 9 and newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- For Java 8; Java 9 and newer will pay attention to maven.compiler.release, specified in a Java-9-and-later
+        profile -->
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+
         <jmh.version>1.32</jmh.version>
         <junit.version>5.8.1</junit.version>
     </properties>
@@ -112,10 +117,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
 
                 <executions>
                     <execution>
@@ -236,6 +237,16 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>java-8-release-target</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+
         <profile>
             <id>release-sign-artifacts</id>
             <activation>


### PR DESCRIPTION
This fixes a strange but seemingly [well-known issue](https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/) where new `ByteBuffer` methods introduced in Java 9 cause `NoSuchMethodErrors` under Java 8 and newer if class files are built with Java 9 or newer. The strategy here is to use the old source/target properties under Java 8 and older and the new `maven.compiler.release` under Java 9 and newer.

This fixes #27.