### PR TITLE
Use an unchecked exception for unsupported MAC algorithms

### DIFF
--- a/src/main/java/com/eatthepath/otp/HmacOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/HmacOneTimePasswordGenerator.java
@@ -58,12 +58,8 @@ public class HmacOneTimePasswordGenerator {
     /**
      * Creates a new HMAC-based one-time password (HOTP) generator using a default password length
      * ({@value com.eatthepath.otp.HmacOneTimePasswordGenerator#DEFAULT_PASSWORD_LENGTH} digits).
-     *
-     * @throws NoSuchAlgorithmException if the underlying JRE doesn't support the
-     * {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM} algorithm, which should never
-     * happen except in cases of serious misconfiguration
      */
-    public HmacOneTimePasswordGenerator() throws NoSuchAlgorithmException {
+    public HmacOneTimePasswordGenerator() {
         this(DEFAULT_PASSWORD_LENGTH);
     }
 
@@ -72,12 +68,8 @@ public class HmacOneTimePasswordGenerator {
      *
      * @param passwordLength the length, in decimal digits, of the one-time passwords to be generated; must be between
      * 6 and 8, inclusive
-     *
-     * @throws NoSuchAlgorithmException if the underlying JRE doesn't support the
-     * {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM} algorithm, which should never
-     * happen except in cases of serious misconfiguration
      */
-    public HmacOneTimePasswordGenerator(final int passwordLength) throws NoSuchAlgorithmException {
+    public HmacOneTimePasswordGenerator(final int passwordLength) {
         this(passwordLength, HOTP_HMAC_ALGORITHM);
     }
 
@@ -92,10 +84,16 @@ public class HmacOneTimePasswordGenerator {
      * HOTP only allows for {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM}, but derived
      * standards like TOTP may allow for other algorithms
      *
-     * @throws NoSuchAlgorithmException if the given algorithm is not supported by the underlying JRE
+     * @throws NoSuchAlgorithmRuntimeException if the given algorithm is not supported by the underlying JRE
      */
-    protected HmacOneTimePasswordGenerator(final int passwordLength, final String algorithm) throws NoSuchAlgorithmException {
-        this.mac = Mac.getInstance(algorithm);
+    protected HmacOneTimePasswordGenerator(final int passwordLength, final String algorithm)
+            throws NoSuchAlgorithmRuntimeException {
+
+        try {
+            this.mac = Mac.getInstance(algorithm);
+        } catch (final NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmRuntimeException(e);
+        }
 
         switch (passwordLength) {
             case 6: {

--- a/src/main/java/com/eatthepath/otp/NoSuchAlgorithmRuntimeException.java
+++ b/src/main/java/com/eatthepath/otp/NoSuchAlgorithmRuntimeException.java
@@ -1,0 +1,25 @@
+package com.eatthepath.otp;
+
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * A runtime exception that indicates that a requested MAC algorithm is not supported by the JVM.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public class NoSuchAlgorithmRuntimeException extends RuntimeException {
+
+    NoSuchAlgorithmRuntimeException(final NoSuchAlgorithmException e) {
+        super(e);
+    }
+
+    /**
+     * Returns the underlying {@link NoSuchAlgorithmException} that caused this exception.
+     *
+     * @return the underlying {@link NoSuchAlgorithmException} that caused this exception
+     */
+    @Override
+    public NoSuchAlgorithmException getCause() {
+        return (NoSuchAlgorithmException) super.getCause();
+    }
+}

--- a/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
@@ -23,7 +23,6 @@ package com.eatthepath.otp;
 import javax.crypto.Mac;
 import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Locale;
@@ -53,23 +52,21 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
     /**
      * A string identifier for the HMAC-SHA256 algorithm (allowed by TOTP).
      */
+    @SuppressWarnings("unused")
     public static final String TOTP_ALGORITHM_HMAC_SHA256 = "HmacSHA256";
 
     /**
      * A string identifier for the HMAC-SHA512 algorithm (allowed by TOTP).
      */
+    @SuppressWarnings("unused")
     public static final String TOTP_ALGORITHM_HMAC_SHA512 = "HmacSHA512";
 
     /**
      * Constructs a new time-based one-time password generator with a default time-step (30 seconds), password length
      * ({@value com.eatthepath.otp.HmacOneTimePasswordGenerator#DEFAULT_PASSWORD_LENGTH} decimal digits), and HMAC
      * algorithm ({@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM}).
-     *
-     * @throws NoSuchAlgorithmException if the underlying JRE doesn't support the
-     * {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM} algorithm, which should never
-     * happen except in cases of serious misconfiguration
      */
-    public TimeBasedOneTimePasswordGenerator() throws NoSuchAlgorithmException {
+    public TimeBasedOneTimePasswordGenerator() {
         this(DEFAULT_TIME_STEP);
     }
 
@@ -79,12 +76,8 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      * algorithm ({@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM}).
      *
      * @param timeStep the time-step for this generator
-     *
-     * @throws NoSuchAlgorithmException if the underlying JRE doesn't support the
-     * {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM} algorithm, which should never
-     * happen except in cases of serious misconfiguration
      */
-    public TimeBasedOneTimePasswordGenerator(final Duration timeStep) throws NoSuchAlgorithmException {
+    public TimeBasedOneTimePasswordGenerator(final Duration timeStep) {
         this(timeStep, HmacOneTimePasswordGenerator.DEFAULT_PASSWORD_LENGTH);
     }
 
@@ -95,12 +88,8 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      * @param timeStep the time-step for this generator
      * @param passwordLength the length, in decimal digits, of the one-time passwords to be generated; must be between
      * 6 and 8, inclusive
-     *
-     * @throws NoSuchAlgorithmException if the underlying JRE doesn't support the
-     * {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM} algorithm, which should never
-     * happen except in cases of serious misconfiguration
      */
-    public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength) throws NoSuchAlgorithmException {
+    public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength) {
         this(timeStep, passwordLength, TOTP_ALGORITHM_HMAC_SHA1);
     }
 
@@ -112,19 +101,21 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      * @param passwordLength the length, in decimal digits, of the one-time passwords to be generated; must be between
      * 6 and 8, inclusive
      * @param algorithm the name of the {@link javax.crypto.Mac} algorithm to use when generating passwords; TOTP allows
-     * for {@value com.eatthepath.otp.TimeBasedOneTimePasswordGenerator#TOTP_ALGORITHM_HMAC_SHA1},
-     * {@value com.eatthepath.otp.TimeBasedOneTimePasswordGenerator#TOTP_ALGORITHM_HMAC_SHA256}, and
-     * {@value com.eatthepath.otp.TimeBasedOneTimePasswordGenerator#TOTP_ALGORITHM_HMAC_SHA512}
+     * for {@value #TOTP_ALGORITHM_HMAC_SHA1}, {@value #TOTP_ALGORITHM_HMAC_SHA256}, and
+     * {@value #TOTP_ALGORITHM_HMAC_SHA512}
      *
-     * @throws NoSuchAlgorithmException if the underlying JRE doesn't support the given algorithm
+     * @throws NoSuchAlgorithmRuntimeException if the given algorithm is {@value #TOTP_ALGORITHM_HMAC_SHA512} and the
+     * JVM does not support that algorithm; all JVMs are required to support {@value #TOTP_ALGORITHM_HMAC_SHA1} and
+     * {@value #TOTP_ALGORITHM_HMAC_SHA256}, but are not required to support {@value #TOTP_ALGORITHM_HMAC_SHA512}
      *
-     * @see com.eatthepath.otp.TimeBasedOneTimePasswordGenerator#TOTP_ALGORITHM_HMAC_SHA1
-     * @see com.eatthepath.otp.TimeBasedOneTimePasswordGenerator#TOTP_ALGORITHM_HMAC_SHA256
-     * @see com.eatthepath.otp.TimeBasedOneTimePasswordGenerator#TOTP_ALGORITHM_HMAC_SHA512
+     * @see #TOTP_ALGORITHM_HMAC_SHA1
+     * @see #TOTP_ALGORITHM_HMAC_SHA256
+     * @see #TOTP_ALGORITHM_HMAC_SHA512
      */
-    public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength, final String algorithm) throws NoSuchAlgorithmException {
-        super(passwordLength, algorithm);
+    public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength, final String algorithm)
+            throws NoSuchAlgorithmRuntimeException {
 
+        super(passwordLength, algorithm);
         this.timeStep = timeStep;
     }
 

--- a/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.stream.Stream;
 
@@ -54,18 +53,18 @@ public class HmacOneTimePasswordGeneratorTest {
 
     @Test
     void testHmacOneTimePasswordGeneratorWithBogusAlgorithm() {
-        assertThrows(NoSuchAlgorithmException.class, () ->
+        assertThrows(NoSuchAlgorithmRuntimeException.class, () ->
                 new HmacOneTimePasswordGenerator(6, "Definitely not a real algorithm"));
     }
 
     @Test
-    void testGetPasswordLength() throws NoSuchAlgorithmException {
+    void testGetPasswordLength() {
         final int passwordLength = 7;
         assertEquals(passwordLength, new HmacOneTimePasswordGenerator(passwordLength).getPasswordLength());
     }
 
     @Test
-    void testGetAlgorithm() throws NoSuchAlgorithmException {
+    void testGetAlgorithm() {
         final String algorithm = "HmacSHA256";
         assertEquals(algorithm, new HmacOneTimePasswordGenerator(6, algorithm).getAlgorithm());
     }
@@ -149,7 +148,7 @@ public class HmacOneTimePasswordGeneratorTest {
         );
     }
 
-    protected HmacOneTimePasswordGenerator getDefaultGenerator() throws NoSuchAlgorithmException {
+    protected HmacOneTimePasswordGenerator getDefaultGenerator() {
         return new HmacOneTimePasswordGenerator();
     }
 }

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Locale;
@@ -56,16 +55,14 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
                     TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA512);
 
     @Override
-    protected HmacOneTimePasswordGenerator getDefaultGenerator() throws NoSuchAlgorithmException {
+    protected HmacOneTimePasswordGenerator getDefaultGenerator() {
         return new TimeBasedOneTimePasswordGenerator();
     }
 
     @Test
-    void testGetTimeStep() throws NoSuchAlgorithmException {
+    void testGetTimeStep() {
         final Duration timeStep = Duration.ofSeconds(97);
-
-        final TimeBasedOneTimePasswordGenerator totp =
-                new TimeBasedOneTimePasswordGenerator(timeStep);
+        final TimeBasedOneTimePasswordGenerator totp = new TimeBasedOneTimePasswordGenerator(timeStep);
 
         assertEquals(timeStep, totp.getTimeStep());
     }


### PR DESCRIPTION
This introduces a `NoSuchAlgorithmRuntimeException` to take the place of `NoSuchAlgorithmException`. The rationale is that, in virtually all cases, a `NoSuchAlgorithmException` is practically impossible because all JVMs are required to support SHA-1 and SHA-256. The one exception is SHA-512, which JVMs are not _required_ to support (but most do).

Re-throwing `NoSuchAlgorithmException` as a `NoSuchAlgorithmRuntimeException` means that callers don't need to catch an exception that can never happen in most cases; in the one case where it _can_ happen, we'll rely on the docs to warn callers that they should be on the lookout for a `NoSuchAlgorithmRuntimeException`.

My hope is that this is a worthwhile tradeoff in favor of API ergonomics, but I welcome feedback!