### PR TITLE
More explicitly link MAC length and key length in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ final Key key;
     final KeyGenerator keyGenerator = KeyGenerator.getInstance(totp.getAlgorithm());
 
     // Key length should match the length of the HMAC output (160 bits for SHA-1, 256 bits
-    // for SHA-256, and 512 bits for SHA-512).
-    keyGenerator.init(160);
+    // for SHA-256, and 512 bits for SHA-512). Note that while Mac#getMacLength() returns a
+    // length in _bytes,_ KeyGenerator#init(int) takes a key length in _bits._
+    final int macLengthInBytes = Mac.getInstance(totp.getAlgorithm()).getMacLength();
+    keyGenerator.init(macLengthInBytes * 8);
 
     key = keyGenerator.generateKey();
 }

--- a/src/test/java/com/eatthepath/otp/ExampleApp.java
+++ b/src/test/java/com/eatthepath/otp/ExampleApp.java
@@ -21,6 +21,7 @@
 package com.eatthepath.otp;
 
 import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
@@ -35,8 +36,10 @@ public class ExampleApp {
             final KeyGenerator keyGenerator = KeyGenerator.getInstance(totp.getAlgorithm());
 
             // Key length should match the length of the HMAC output (160 bits for SHA-1, 256 bits
-            // for SHA-256, and 512 bits for SHA-512).
-            keyGenerator.init(160);
+            // for SHA-256, and 512 bits for SHA-512). Note that while Mac#getMacLength() returns a
+            // length in _bytes,_ KeyGenerator#init(int) takes a key length in _bits._
+            final int macLengthInBytes = Mac.getInstance(totp.getAlgorithm()).getMacLength();
+            keyGenerator.init(macLengthInBytes * 8);
 
             key = keyGenerator.generateKey();
         }


### PR DESCRIPTION
This is a very modest update to the example app/README that more explicitly links the MAC length for the chosen algorithm to an appropriate key length and demonstrates how to get at the MAC length in a reliable, programmatic way (instead of just pulling random trivia from who-knows-where on the internet).