### PR TITLE
Don't extend `HmacOneTimePasswordGenerator` in `TimeBasedOneTimePasswordGenerator`

### DIFF
--- a/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
@@ -35,7 +35,8 @@ import java.util.Locale;
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */
-public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenerator {
+public class TimeBasedOneTimePasswordGenerator {
+    private final HmacOneTimePasswordGenerator hotp;
     private final Duration timeStep;
 
     /**
@@ -115,7 +116,7 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
     public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength, final String algorithm)
             throws NoSuchAlgorithmRuntimeException {
 
-        super(passwordLength, algorithm);
+        this.hotp = new HmacOneTimePasswordGenerator(passwordLength, algorithm);
         this.timeStep = timeStep;
     }
 
@@ -131,7 +132,7 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      * @throws InvalidKeyException if the given key is inappropriate for initializing the {@link Mac} for this generator
      */
     public int generateOneTimePassword(final Key key, final Instant timestamp) throws InvalidKeyException {
-        return this.generateOneTimePassword(key, timestamp.toEpochMilli() / this.timeStep.toMillis());
+        return this.hotp.generateOneTimePassword(key, timestamp.toEpochMilli() / this.timeStep.toMillis());
     }
 
     /**
@@ -163,7 +164,7 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      * @throws InvalidKeyException if the given key is inappropriate for initializing the {@link Mac} for this generator
      */
     public String generateOneTimePasswordString(final Key key, final Instant timestamp, final Locale locale) throws InvalidKeyException {
-        return this.formatOneTimePassword(this.generateOneTimePassword(key, timestamp), locale);
+        return this.hotp.formatOneTimePassword(this.generateOneTimePassword(key, timestamp), locale);
     }
 
     /**
@@ -173,5 +174,23 @@ public class TimeBasedOneTimePasswordGenerator extends HmacOneTimePasswordGenera
      */
     public Duration getTimeStep() {
         return this.timeStep;
+    }
+
+    /**
+     * Returns the length, in decimal digits, of passwords produced by this generator.
+     *
+     * @return the length, in decimal digits, of passwords produced by this generator
+     */
+    public int getPasswordLength() {
+        return this.hotp.getPasswordLength();
+    }
+
+    /**
+     * Returns the name of the HMAC algorithm used by this generator.
+     *
+     * @return the name of the HMAC algorithm used by this generator
+     */
+    public String getAlgorithm() {
+        return this.hotp.getAlgorithm();
     }
 }

--- a/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
@@ -76,7 +76,7 @@ public class HmacOneTimePasswordGeneratorTest {
     @ParameterizedTest
     @MethodSource("argumentsForTestGenerateOneTimePasswordHotp")
     void testGenerateOneTimePassword(final int counter, final int expectedOneTimePassword) throws Exception {
-        assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePassword(HOTP_KEY, counter));
+        assertEquals(expectedOneTimePassword, new HmacOneTimePasswordGenerator().generateOneTimePassword(HOTP_KEY, counter));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class HmacOneTimePasswordGeneratorTest {
     @MethodSource("argumentsForTestGenerateOneTimePasswordStringHotp")
     void testGenerateOneTimePasswordString(final int counter, final String expectedOneTimePassword) throws Exception {
         Locale.setDefault(Locale.US);
-        assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePasswordString(HOTP_KEY, counter));
+        assertEquals(expectedOneTimePassword, new HmacOneTimePasswordGenerator().generateOneTimePasswordString(HOTP_KEY, counter));
     }
 
     private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringHotp() {
@@ -128,7 +128,7 @@ public class HmacOneTimePasswordGeneratorTest {
     @MethodSource("argumentsForTestGenerateOneTimePasswordStringLocaleHotp")
     void testGenerateOneTimePasswordStringLocale(final int counter, final Locale locale, final String expectedOneTimePassword) throws Exception {
         Locale.setDefault(Locale.US);
-        assertEquals(expectedOneTimePassword, this.getDefaultGenerator().generateOneTimePasswordString(HOTP_KEY, counter, locale));
+        assertEquals(expectedOneTimePassword, new HmacOneTimePasswordGenerator().generateOneTimePasswordString(HOTP_KEY, counter, locale));
     }
 
     private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringLocaleHotp() {
@@ -146,9 +146,5 @@ public class HmacOneTimePasswordGeneratorTest {
                 arguments(8, locale, "३९९८७१"),
                 arguments(9, locale, "५२०४८९")
         );
-    }
-
-    protected HmacOneTimePasswordGenerator getDefaultGenerator() {
-        return new HmacOneTimePasswordGenerator();
     }
 }

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGeneratorTest {
+public class TimeBasedOneTimePasswordGeneratorTest {
 
     private static final String HMAC_SHA1_ALGORITHM = "HmacSHA1";
     private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
@@ -54,17 +54,22 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
             new SecretKeySpec("1234567890123456789012345678901234567890123456789012345678901234".getBytes(StandardCharsets.US_ASCII),
                     TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA512);
 
-    @Override
-    protected HmacOneTimePasswordGenerator getDefaultGenerator() {
-        return new TimeBasedOneTimePasswordGenerator();
+    @Test
+    void testGetPasswordLength() {
+        final int passwordLength = 7;
+        assertEquals(passwordLength, new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), passwordLength).getPasswordLength());
+    }
+
+    @Test
+    void testGetAlgorithm() {
+        final String algorithm = TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA256;
+        assertEquals(algorithm, new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 6, algorithm).getAlgorithm());
     }
 
     @Test
     void testGetTimeStep() {
         final Duration timeStep = Duration.ofSeconds(97);
-        final TimeBasedOneTimePasswordGenerator totp = new TimeBasedOneTimePasswordGenerator(timeStep);
-
-        assertEquals(timeStep, totp.getTimeStep());
+        assertEquals(timeStep, new TimeBasedOneTimePasswordGenerator(timeStep).getTimeStep());
     }
 
     /**


### PR DESCRIPTION
Prior to this change,`TimeBasedOneTimePasswordGenerator` extends `HmacOneTimePasswordGenerator`. That moooooostly makes sense (TOTP as a standard is, in fact, an extension of HOTP), but creates a couple weird situations in the public API. In particular, it creates a situation where counter-based password-generation methods are visible in `TimeBasedOneTimePasswordGenerator` instances, and it doesn't really make sense to be requesting one-time passwords from a TOTP generator by counter instead of by time.

After this change, `TimeBasedOneTimePasswordGenerator` no longer has a base class, and instead delegates to a private `HmacOneTimePasswordGenerator` instance for password generation. That means its public interface will no longer have counter-based OTP-generation methods. This is _technically_ a breaking API change, but only for callers who were trying to do counter-based operations with a TOTP generator.

Feedback is very welcome!