### PR TITLE
Use `assumeTrue` when running SHA-512-based tests

### DIFF
--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -35,6 +36,7 @@ import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGeneratorTest {
@@ -43,17 +45,14 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
     private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
     private static final String HMAC_SHA512_ALGORITHM = "HmacSHA512";
 
-    private static final Key HMAC_SHA1_KEY =
-            new SecretKeySpec("12345678901234567890".getBytes(StandardCharsets.US_ASCII),
-                    TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA1);
+    private static final byte[] HMAC_SHA1_KEY_BYTES =
+            "12345678901234567890".getBytes(StandardCharsets.US_ASCII);
 
-    private static final Key HMAC_SHA256_KEY =
-            new SecretKeySpec("12345678901234567890123456789012".getBytes(StandardCharsets.US_ASCII),
-                    TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA256);
+    private static final byte[] HMAC_SHA256_KEY_BYTES =
+            "12345678901234567890123456789012".getBytes(StandardCharsets.US_ASCII);
 
-    private static final Key HMAC_SHA512_KEY =
-            new SecretKeySpec("1234567890123456789012345678901234567890123456789012345678901234".getBytes(StandardCharsets.US_ASCII),
-                    TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA512);
+    private static final byte[] HMAC_SHA512_KEY_BYTES =
+            "1234567890123456789012345678901234567890123456789012345678901234".getBytes(StandardCharsets.US_ASCII);
 
     @Override
     protected HmacOneTimePasswordGenerator getDefaultGenerator() throws NoSuchAlgorithmException {
@@ -79,82 +78,88 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
      */
     @ParameterizedTest
     @MethodSource("argumentsForTestGenerateOneTimePasswordTotp")
-    void testGenerateOneTimePasswordTotp(final String algorithm, final Key key, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
+    void testGenerateOneTimePasswordTotp(final String algorithm, final byte[] keyBytes, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
+        assumeAlgorithmSupported(algorithm);
 
         final TimeBasedOneTimePasswordGenerator totp =
                 new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
 
         final Instant timestamp = Instant.ofEpochSecond(epochSeconds);
+        final Key key = new SecretKeySpec(keyBytes, algorithm);
 
         assertEquals(expectedOneTimePassword, totp.generateOneTimePassword(key, timestamp));
     }
 
     private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordTotp() {
         return Stream.of(
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,            59L, 94287082),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111109L,  7081804),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111111L, 14050471),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1234567890L, 89005924),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    2000000000L, 69279037),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,   20000000000L, 65353130),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,          59L, 46119246),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111109L, 68084774),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111111L, 67062674),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1234567890L, 91819424),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  2000000000L, 90698825),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY, 20000000000L, 77737706),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,          59L, 90693936),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111109L, 25091201),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111111L, 99943326),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1234567890L, 93441116),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  2000000000L, 38618901),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY, 20000000000L, 47863826)
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,            59L, 94287082),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111109L,  7081804),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111111L, 14050471),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1234567890L, 89005924),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    2000000000L, 69279037),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,   20000000000L, 65353130),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,          59L, 46119246),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1111111109L, 68084774),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1111111111L, 67062674),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1234567890L, 91819424),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  2000000000L, 90698825),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES, 20000000000L, 77737706),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,          59L, 90693936),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1111111109L, 25091201),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1111111111L, 99943326),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1234567890L, 93441116),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  2000000000L, 38618901),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES, 20000000000L, 47863826)
         );
     }
 
     @ParameterizedTest
     @MethodSource("argumentsForTestGenerateOneTimePasswordStringTotp")
-    void testGenerateOneTimePasswordStringTotp(final String algorithm, final Key key, final long epochSeconds, final String expectedOneTimePassword) throws Exception {
+    void testGenerateOneTimePasswordStringTotp(final String algorithm, final byte[] keyBytes, final long epochSeconds, final String expectedOneTimePassword) throws Exception {
+        assumeAlgorithmSupported(algorithm);
 
         final TimeBasedOneTimePasswordGenerator totp =
                 new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
 
         final Instant timestamp = Instant.ofEpochSecond(epochSeconds);
+        final Key key = new SecretKeySpec(keyBytes, algorithm);
 
         assertEquals(expectedOneTimePassword, totp.generateOneTimePasswordString(key, timestamp));
     }
 
     private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringTotp() {
         return Stream.of(
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,            59L, "94287082"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111109L, "07081804"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111111L, "14050471"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1234567890L, "89005924"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    2000000000L, "69279037"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,   20000000000L, "65353130"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,          59L, "46119246"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111109L, "68084774"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111111L, "67062674"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1234567890L, "91819424"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  2000000000L, "90698825"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY, 20000000000L, "77737706"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,          59L, "90693936"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111109L, "25091201"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111111L, "99943326"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1234567890L, "93441116"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  2000000000L, "38618901"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY, 20000000000L, "47863826")
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,            59L, "94287082"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111109L, "07081804"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111111L, "14050471"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1234567890L, "89005924"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    2000000000L, "69279037"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,   20000000000L, "65353130"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,          59L, "46119246"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1111111109L, "68084774"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1111111111L, "67062674"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1234567890L, "91819424"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  2000000000L, "90698825"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES, 20000000000L, "77737706"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,          59L, "90693936"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1111111109L, "25091201"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1111111111L, "99943326"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1234567890L, "93441116"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  2000000000L, "38618901"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES, 20000000000L, "47863826")
         );
     }
 
     @ParameterizedTest
     @MethodSource("argumentsForTestGenerateOneTimePasswordStringLocaleTotp")
-    void testGenerateOneTimePasswordStringLocaleTotp(final String algorithm, final Key key, final long epochSeconds, final Locale locale, final String expectedOneTimePassword) throws Exception {
+    void testGenerateOneTimePasswordStringLocaleTotp(final String algorithm, final byte[] keyBytes, final long epochSeconds, final Locale locale, final String expectedOneTimePassword) throws Exception {
+        assumeAlgorithmSupported(algorithm);
 
         final TimeBasedOneTimePasswordGenerator totp =
                 new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 8, algorithm);
 
         final Instant timestamp = Instant.ofEpochSecond(epochSeconds);
+        final Key key = new SecretKeySpec(keyBytes, algorithm);
 
         assertEquals(expectedOneTimePassword, totp.generateOneTimePasswordString(key, timestamp, locale));
     }
@@ -163,24 +168,37 @@ public class TimeBasedOneTimePasswordGeneratorTest extends HmacOneTimePasswordGe
         final Locale locale = Locale.forLanguageTag("hi-IN-u-nu-Deva");
 
         return Stream.of(
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,            59L, locale, "९४२८७०८२"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111109L, locale, "०७०८१८०४"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1111111111L, locale, "१४०५०४७१"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    1234567890L, locale, "८९००५९२४"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,    2000000000L, locale, "६९२७९०३७"),
-                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY,   20000000000L, locale, "६५३५३१३०"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,          59L, locale, "४६११९२४६"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111109L, locale, "६८०८४७७४"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1111111111L, locale, "६७०६२६७४"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  1234567890L, locale, "९१८१९४२४"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY,  2000000000L, locale, "९०६९८८२५"),
-                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY, 20000000000L, locale, "७७७३७७०६"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,          59L, locale, "९०६९३९३६"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111109L, locale, "२५०९१२०१"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1111111111L, locale, "९९९४३३२६"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  1234567890L, locale, "९३४४१११६"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY,  2000000000L, locale, "३८६१८९०१"),
-                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY, 20000000000L, locale, "४७८६३८२६")
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,            59L, locale, "९४२८७०८२"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111109L, locale, "०७०८१८०४"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111111L, locale, "१४०५०४७१"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1234567890L, locale, "८९००५९२४"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    2000000000L, locale, "६९२७९०३७"),
+                arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,   20000000000L, locale, "६५३५३१३०"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,          59L, locale, "४६११९२४६"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1111111109L, locale, "६८०८४७७४"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1111111111L, locale, "६७०६२६७४"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  1234567890L, locale, "९१८१९४२४"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES,  2000000000L, locale, "९०६९८८२५"),
+                arguments(HMAC_SHA256_ALGORITHM, HMAC_SHA256_KEY_BYTES, 20000000000L, locale, "७७७३७७०६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,          59L, locale, "९०६९३९३६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1111111109L, locale, "२५०९१२०१"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1111111111L, locale, "९९९४३३२६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  1234567890L, locale, "९३४४१११६"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES,  2000000000L, locale, "३८६१८९०१"),
+                arguments(HMAC_SHA512_ALGORITHM, HMAC_SHA512_KEY_BYTES, 20000000000L, locale, "४७८६३८२६")
         );
+    }
+
+    private static void assumeAlgorithmSupported(final String algorithm) {
+        boolean algorithmSupported;
+
+        try {
+            Mac.getInstance(algorithm);
+            algorithmSupported = true;
+        } catch (final NoSuchAlgorithmException e) {
+            algorithmSupported = false;
+        }
+
+        assumeTrue(algorithmSupported, "Algorithm not supported: " + algorithm);
     }
 }


### PR DESCRIPTION
Most JREs support SHA-512, but not all do. This change adds an `assumeTrue` call to tests that makes sure the algorithm in question is supported by the JRE. If the JRE does _not_ support SHA-512, the test will abort rather than failing. This should allow folks to build/test java-otp even if their immediate JDK doesn't support SHA-512.

As always, feedback is very welcome!