### PR TITLE
[CI] Use built-in caching from `setup-java` action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,6 @@ jobs:
       with:
         distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java }}
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        cache: 'maven'
     - name: Test with Maven
       run: mvn verify -B --file pom.xml


### PR DESCRIPTION
https://github.com/actions/setup-java#caching-packages-dependencies:
> `setup-java` action has a built-in functionality for caching and restoring dependencies. It uses actions/cache under hood for caching dependencies but requires less configuration settings. 