### PR TITLE
[CI] Use `temurin` instead of deprecated `adopt`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distribution: [ 'zulu', 'adopt' ]
+        distribution: [ 'zulu', 'temurin' ]
         java: [8, 11, 13, 15]
       fail-fast: false
     name: JDK ${{ matrix.java }} (${{ matrix.distribution }})


### PR DESCRIPTION
https://github.com/actions/setup-java#supported-distributions:
> **NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
