### PR TITLE
[CI] Prevent duplicate builds for PRs from base repo branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Build/test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   test:


### PR DESCRIPTION
It will help to avoid such cases:
<img width="945" alt="duplicate-builds" src="https://user-images.githubusercontent.com/5081226/163544245-c6d9761b-1d7c-44bf-bb91-bdaa4d65d1ee.png">

