### PR TITLE
Rename `NoSuchAlgorithmRuntimeException` to `UncheckedNoSuchAlgorithmException`

### DIFF
--- a/src/main/java/com/eatthepath/otp/HmacOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/HmacOneTimePasswordGenerator.java
@@ -88,13 +88,13 @@ public class HmacOneTimePasswordGenerator {
      * HOTP only allows for {@value com.eatthepath.otp.HmacOneTimePasswordGenerator#HOTP_HMAC_ALGORITHM}, but derived
      * standards like TOTP may allow for other algorithms
      *
-     * @throws NoSuchAlgorithmRuntimeException if the given algorithm is not supported by the underlying JRE
+     * @throws UncheckedNoSuchAlgorithmException if the given algorithm is not supported by the underlying JRE
      */
-    HmacOneTimePasswordGenerator(final int passwordLength, final String algorithm) throws NoSuchAlgorithmRuntimeException {
+    HmacOneTimePasswordGenerator(final int passwordLength, final String algorithm) throws UncheckedNoSuchAlgorithmException {
         try {
             this.mac = Mac.getInstance(algorithm);
         } catch (final NoSuchAlgorithmException e) {
-            throw new NoSuchAlgorithmRuntimeException(e);
+            throw new UncheckedNoSuchAlgorithmException(e);
         }
 
         switch (passwordLength) {

--- a/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
@@ -108,7 +108,7 @@ public class TimeBasedOneTimePasswordGenerator {
      * for {@value #TOTP_ALGORITHM_HMAC_SHA1}, {@value #TOTP_ALGORITHM_HMAC_SHA256}, and
      * {@value #TOTP_ALGORITHM_HMAC_SHA512}
      *
-     * @throws NoSuchAlgorithmRuntimeException if the given algorithm is {@value #TOTP_ALGORITHM_HMAC_SHA512} and the
+     * @throws UncheckedNoSuchAlgorithmException if the given algorithm is {@value #TOTP_ALGORITHM_HMAC_SHA512} and the
      * JVM does not support that algorithm; all JVMs are required to support {@value #TOTP_ALGORITHM_HMAC_SHA1} and
      * {@value #TOTP_ALGORITHM_HMAC_SHA256}, but are not required to support {@value #TOTP_ALGORITHM_HMAC_SHA512}
      *
@@ -117,7 +117,7 @@ public class TimeBasedOneTimePasswordGenerator {
      * @see #TOTP_ALGORITHM_HMAC_SHA512
      */
     public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength, final String algorithm)
-            throws NoSuchAlgorithmRuntimeException {
+            throws UncheckedNoSuchAlgorithmException {
 
         this.hotp = new HmacOneTimePasswordGenerator(passwordLength, algorithm);
         this.timeStep = timeStep;

--- a/src/main/java/com/eatthepath/otp/UncheckedNoSuchAlgorithmException.java
+++ b/src/main/java/com/eatthepath/otp/UncheckedNoSuchAlgorithmException.java
@@ -3,14 +3,19 @@ package com.eatthepath.otp;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * A runtime exception that indicates that a requested MAC algorithm is not supported by the JVM.
+ * Wraps a {@link NoSuchAlgorithmException} with an unchecked exception.
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */
-public class NoSuchAlgorithmRuntimeException extends RuntimeException {
+public class UncheckedNoSuchAlgorithmException extends RuntimeException {
 
-    NoSuchAlgorithmRuntimeException(final NoSuchAlgorithmException e) {
-        super(e);
+    /**
+     * Constructs a new unchecked {@code NoSuchAlgorithmException} instance.
+     *
+     * @param cause the underlying {@code NoSuchAlgorithmException}
+     */
+    UncheckedNoSuchAlgorithmException(final NoSuchAlgorithmException cause) {
+        super(cause);
     }
 
     /**

--- a/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
@@ -53,7 +53,7 @@ public class HmacOneTimePasswordGeneratorTest {
 
     @Test
     void testHmacOneTimePasswordGeneratorWithBogusAlgorithm() {
-        assertThrows(NoSuchAlgorithmRuntimeException.class, () ->
+        assertThrows(UncheckedNoSuchAlgorithmException.class, () ->
                 new HmacOneTimePasswordGenerator(6, "Definitely not a real algorithm"));
     }
 

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -193,11 +193,10 @@ public class TimeBasedOneTimePasswordGeneratorTest {
     }
 
     private static void assumeAlgorithmSupported(final String algorithm) {
-        boolean algorithmSupported;
+        boolean algorithmSupported = true;
 
         try {
             Mac.getInstance(algorithm);
-            algorithmSupported = true;
         } catch (final NoSuchAlgorithmException e) {
             algorithmSupported = false;
         }


### PR DESCRIPTION
As a follow-up to #29, this renames `NoSuchAlgorithmRuntimeException` to `UncheckedNoSuchAlgorithmException` to match the naming precedent set by [`UncheckedIOException`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/UncheckedIOException.html).