### PR TITLE
Clean up `pom.xml` and update release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <connection>scm:git:https://github.com/jchambers/java-otp.git</connection>
         <developerConnection>scm:git:git@github.com:jchambers/java-otp.git</developerConnection>
         <url>https://github.com/jchambers/java-otp</url>
-        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -68,21 +68,13 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.5</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <!-- Add benchmarks as a source directory -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.6.1</version>
+
                 <executions>
                     <execution>
                         <id>add-test-source</id>
@@ -161,6 +153,21 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.8</version>
+
+                <configuration>
+                    <!-- Prevent gpg from using pinentry programs;
+                    see https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml -->
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.5.0</version>
                 <configuration>
@@ -209,17 +216,16 @@
             </plugin>
 
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.5</version>
+            </plugin>
 
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.10.0</version>
                 <extensions>true</extensions>
-
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -238,7 +244,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.8</version>
+
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- For Java 8; Java 9 and newer will pay attention to maven.compiler.release, specified in a Java-9-and-later
-        profile -->
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-
         <jmh.version>1.37</jmh.version>
         <junit.version>5.14.3</junit.version>
     </properties>
@@ -115,6 +110,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
+
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                    <release>8</release>
+                </configuration>
 
                 <executions>
                     <execution>
@@ -231,16 +232,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>java-8-release-target</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-        </profile>
-
         <profile>
             <id>release-sign-artifacts</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,7 @@
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This cleans up `pom.xml` in general by removing redundant, over-complicated, or outdated bits. Additionally, the [process for releasing artifacts to Maven Central](https://central.sonatype.org/publish/publish-portal-maven/) has changed, and this updates our approach to match.