### PR TITLE
Tidy up tests

### DIFF
--- a/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
+++ b/src/main/java/com/eatthepath/otp/TimeBasedOneTimePasswordGenerator.java
@@ -119,6 +119,10 @@ public class TimeBasedOneTimePasswordGenerator {
     public TimeBasedOneTimePasswordGenerator(final Duration timeStep, final int passwordLength, final String algorithm)
             throws UncheckedNoSuchAlgorithmException {
 
+        if (timeStep.toMillis() <= 0) {
+            throw new IllegalArgumentException("Time step must be at least 1 millisecond");
+        }
+
         this.hotp = new HmacOneTimePasswordGenerator(passwordLength, algorithm);
         this.timeStep = timeStep;
     }

--- a/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/HmacOneTimePasswordGeneratorTest.java
@@ -29,15 +29,16 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Locale;
-import java.util.Random;
 import java.util.concurrent.*;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class HmacOneTimePasswordGeneratorTest {
+class HmacOneTimePasswordGeneratorTest {
 
     private static final Key HOTP_KEY =
             new SecretKeySpec("12345678901234567890".getBytes(StandardCharsets.US_ASCII),
@@ -57,17 +58,17 @@ public class HmacOneTimePasswordGeneratorTest {
     };
 
     @Test
-    void testHmacOneTimePasswordGeneratorWithShortPasswordLength() {
+    void hmacOneTimePasswordGeneratorWithShortPasswordLength() {
         assertThrows(IllegalArgumentException.class, () -> new HmacOneTimePasswordGenerator(5));
     }
 
     @Test
-    void testHmacOneTimePasswordGeneratorWithLongPasswordLength() {
+    void hmacOneTimePasswordGeneratorWithLongPasswordLength() {
         assertThrows(IllegalArgumentException.class, () -> new HmacOneTimePasswordGenerator(9));
     }
 
     @Test
-    void testHmacOneTimePasswordGeneratorWithBogusAlgorithm() {
+    void hmacOneTimePasswordGeneratorWithBogusAlgorithm() {
         final UncheckedNoSuchAlgorithmException exception = assertThrows(UncheckedNoSuchAlgorithmException.class, () ->
                 new HmacOneTimePasswordGenerator(6, "Definitely not a real algorithm"));
 
@@ -75,13 +76,13 @@ public class HmacOneTimePasswordGeneratorTest {
     }
 
     @Test
-    void testGetPasswordLength() {
+    void getPasswordLength() {
         final int passwordLength = 7;
         assertEquals(passwordLength, new HmacOneTimePasswordGenerator(passwordLength).getPasswordLength());
     }
 
     @Test
-    void testGetAlgorithm() {
+    void getAlgorithm() {
         final String algorithm = "HmacSHA256";
         assertEquals(algorithm, new HmacOneTimePasswordGenerator(6, algorithm).getAlgorithm());
     }
@@ -91,13 +92,18 @@ public class HmacOneTimePasswordGeneratorTest {
      * <a href="https://tools.ietf.org/html/rfc4226#appendix-D">RFC&nbsp;4226, Appendix D</a>.
      */
     @ParameterizedTest
-    @MethodSource("argumentsForTestGenerateOneTimePasswordHotp")
-    void testGenerateOneTimePassword(final int counter, final int expectedOneTimePassword) throws Exception {
+    @MethodSource
+    void generateOneTimePassword(final int counter, final int expectedOneTimePassword) throws Exception {
         assertEquals(expectedOneTimePassword, new HmacOneTimePasswordGenerator().generateOneTimePassword(HOTP_KEY, counter));
     }
 
+    private static Stream<Arguments> generateOneTimePassword() {
+        return IntStream.range(0, TEST_VECTORS.length)
+            .mapToObj(counter -> Arguments.of(counter, TEST_VECTORS[counter]));
+    }
+
     @Test
-    void testGenerateOneTimePasswordRepeated() throws Exception {
+    void generateOneTimePasswordRepeated() throws Exception {
         final HmacOneTimePasswordGenerator hotpGenerator = new HmacOneTimePasswordGenerator();
 
         for (int counter = 0; counter < TEST_VECTORS.length; counter++) {
@@ -105,41 +111,26 @@ public class HmacOneTimePasswordGeneratorTest {
         }
     }
 
-    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordHotp() {
-        final Stream.Builder<Arguments> streamBuilder = Stream.builder();
-
-        for (int counter = 0; counter < TEST_VECTORS.length; counter++) {
-            streamBuilder.add(Arguments.of(counter, TEST_VECTORS[counter]));
-        }
-
-        return streamBuilder.build();
-    }
-
     @ParameterizedTest
-    @MethodSource("argumentsForTestGenerateOneTimePasswordStringHotp")
-    void testGenerateOneTimePasswordString(final int counter, final String expectedOneTimePassword) throws Exception {
+    @MethodSource
+    void generateOneTimePasswordString(final int counter, final String expectedOneTimePassword) throws Exception {
         Locale.setDefault(Locale.US);
         assertEquals(expectedOneTimePassword, new HmacOneTimePasswordGenerator().generateOneTimePasswordString(HOTP_KEY, counter));
     }
 
-    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringHotp() {
-        final Stream.Builder<Arguments> streamBuilder = Stream.builder();
-
-        for (int counter = 0; counter < TEST_VECTORS.length; counter++) {
-            streamBuilder.add(Arguments.of(counter, String.valueOf(TEST_VECTORS[counter])));
-        }
-
-        return streamBuilder.build();
+    private static Stream<Arguments> generateOneTimePasswordString() {
+        return IntStream.range(0, TEST_VECTORS.length)
+            .mapToObj(counter -> Arguments.of(counter, String.valueOf(TEST_VECTORS[counter])));
     }
 
     @ParameterizedTest
-    @MethodSource("argumentsForTestGenerateOneTimePasswordStringLocaleHotp")
-    void testGenerateOneTimePasswordStringLocale(final int counter, final Locale locale, final String expectedOneTimePassword) throws Exception {
+    @MethodSource
+    void generateOneTimePasswordStringLocale(final int counter, final Locale locale, final String expectedOneTimePassword) throws Exception {
         Locale.setDefault(Locale.US);
         assertEquals(expectedOneTimePassword, new HmacOneTimePasswordGenerator().generateOneTimePasswordString(HOTP_KEY, counter, locale));
     }
 
-    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringLocaleHotp() {
+    private static Stream<Arguments> generateOneTimePasswordStringLocale() {
         final Locale locale = Locale.forLanguageTag("hi-IN-u-nu-Deva");
 
         return Stream.of(
@@ -157,10 +148,10 @@ public class HmacOneTimePasswordGeneratorTest {
     }
 
     @Test
-    void testConcurrent() throws InterruptedException {
+    void generateOneTimePasswordConcurrent() throws InterruptedException {
         final int iterations = 10_000;
         final int threadCount = Runtime.getRuntime().availableProcessors() * 4;
-        final CountDownLatch threadStartLatch = new CountDownLatch(threadCount);
+        final CyclicBarrier cyclicBarrier = new CyclicBarrier(threadCount);
         final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         @SuppressWarnings("unchecked") final CompletableFuture<Boolean>[] futures = new CompletableFuture[threadCount];
 
@@ -168,19 +159,16 @@ public class HmacOneTimePasswordGeneratorTest {
 
         for (int thread = 0; thread < threadCount; thread++) {
             futures[thread] = CompletableFuture.supplyAsync(() -> {
-                final Random random = new Random();
                 boolean allMatched = true;
 
-                threadStartLatch.countDown();
-
                 try {
-                    threadStartLatch.await();
-                } catch (final InterruptedException e) {
+                    cyclicBarrier.await();
+                } catch (final InterruptedException | BrokenBarrierException e) {
                     throw new RuntimeException(e);
                 }
 
                 for (int i = 0; i < iterations; i++) {
-                    final int counter = random.nextInt(TEST_VECTORS.length);
+                    final int counter = ThreadLocalRandom.current().nextInt(TEST_VECTORS.length);
 
                     try {
                         if (hotpGenerator.generateOneTimePassword(HOTP_KEY, counter) != TEST_VECTORS[counter]) {
@@ -197,9 +185,7 @@ public class HmacOneTimePasswordGeneratorTest {
 
         CompletableFuture.allOf(futures).join();
 
-        for (final CompletableFuture<Boolean> future : futures) {
-            assertTrue(future.join());
-        }
+        assertTrue(Arrays.stream(futures).allMatch(CompletableFuture::join));
 
         executorService.shutdown();
         assertTrue(executorService.awaitTermination(1, TimeUnit.SECONDS));

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-public class TimeBasedOneTimePasswordGeneratorTest {
+class TimeBasedOneTimePasswordGeneratorTest {
 
     private static final String HMAC_SHA1_ALGORITHM = "HmacSHA1";
     private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
@@ -55,19 +55,19 @@ public class TimeBasedOneTimePasswordGeneratorTest {
             "1234567890123456789012345678901234567890123456789012345678901234".getBytes(StandardCharsets.US_ASCII);
 
     @Test
-    void testGetPasswordLength() {
+    void getPasswordLength() {
         final int passwordLength = 7;
         assertEquals(passwordLength, new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), passwordLength).getPasswordLength());
     }
 
     @Test
-    void testGetAlgorithm() {
+    void getAlgorithm() {
         final String algorithm = TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA256;
         assertEquals(algorithm, new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30), 6, algorithm).getAlgorithm());
     }
 
     @Test
-    void testGetTimeStep() {
+    void getTimeStep() {
         final Duration timeStep = Duration.ofSeconds(97);
         assertEquals(timeStep, new TimeBasedOneTimePasswordGenerator(timeStep).getTimeStep());
     }
@@ -80,8 +80,8 @@ public class TimeBasedOneTimePasswordGeneratorTest {
      * different keys are used for each of the various HMAC algorithms.
      */
     @ParameterizedTest
-    @MethodSource("argumentsForTestGenerateOneTimePasswordTotp")
-    void testGenerateOneTimePasswordTotp(final String algorithm, final byte[] keyBytes, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
+    @MethodSource
+    void generateOneTimePassword(final String algorithm, final byte[] keyBytes, final long epochSeconds, final int expectedOneTimePassword) throws Exception {
         assumeAlgorithmSupported(algorithm);
 
         final TimeBasedOneTimePasswordGenerator totp =
@@ -93,7 +93,7 @@ public class TimeBasedOneTimePasswordGeneratorTest {
         assertEquals(expectedOneTimePassword, totp.generateOneTimePassword(key, timestamp));
     }
 
-    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordTotp() {
+    private static Stream<Arguments> generateOneTimePassword() {
         return Stream.of(
                 arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,            59L, 94287082),
                 arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111109L,  7081804),
@@ -117,8 +117,8 @@ public class TimeBasedOneTimePasswordGeneratorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("argumentsForTestGenerateOneTimePasswordStringTotp")
-    void testGenerateOneTimePasswordStringTotp(final String algorithm, final byte[] keyBytes, final long epochSeconds, final String expectedOneTimePassword) throws Exception {
+    @MethodSource
+    void generateOneTimePasswordString(final String algorithm, final byte[] keyBytes, final long epochSeconds, final String expectedOneTimePassword) throws Exception {
         assumeAlgorithmSupported(algorithm);
 
         final TimeBasedOneTimePasswordGenerator totp =
@@ -130,7 +130,7 @@ public class TimeBasedOneTimePasswordGeneratorTest {
         assertEquals(expectedOneTimePassword, totp.generateOneTimePasswordString(key, timestamp));
     }
 
-    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringTotp() {
+    private static Stream<Arguments> generateOneTimePasswordString() {
         return Stream.of(
                 arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,            59L, "94287082"),
                 arguments(HMAC_SHA1_ALGORITHM,   HMAC_SHA1_KEY_BYTES,    1111111109L, "07081804"),
@@ -154,8 +154,8 @@ public class TimeBasedOneTimePasswordGeneratorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("argumentsForTestGenerateOneTimePasswordStringLocaleTotp")
-    void testGenerateOneTimePasswordStringLocaleTotp(final String algorithm, final byte[] keyBytes, final long epochSeconds, final Locale locale, final String expectedOneTimePassword) throws Exception {
+    @MethodSource
+    void generateOneTimePasswordStringLocale(final String algorithm, final byte[] keyBytes, final long epochSeconds, final Locale locale, final String expectedOneTimePassword) throws Exception {
         assumeAlgorithmSupported(algorithm);
 
         final TimeBasedOneTimePasswordGenerator totp =
@@ -167,7 +167,7 @@ public class TimeBasedOneTimePasswordGeneratorTest {
         assertEquals(expectedOneTimePassword, totp.generateOneTimePasswordString(key, timestamp, locale));
     }
 
-    private static Stream<Arguments> argumentsForTestGenerateOneTimePasswordStringLocaleTotp() {
+    private static Stream<Arguments> generateOneTimePasswordStringLocale() {
         final Locale locale = Locale.forLanguageTag("hi-IN-u-nu-Deva");
 
         return Stream.of(

--- a/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
+++ b/src/test/java/com/eatthepath/otp/TimeBasedOneTimePasswordGeneratorTest.java
@@ -36,6 +36,7 @@ import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -53,6 +54,13 @@ class TimeBasedOneTimePasswordGeneratorTest {
 
     private static final byte[] HMAC_SHA512_KEY_BYTES =
             "1234567890123456789012345678901234567890123456789012345678901234".getBytes(StandardCharsets.US_ASCII);
+
+    @Test
+    void timeBasedOneTimePasswordGeneratorWithNonPositiveTimeStamp() {
+        assertThrows(IllegalArgumentException.class, () -> new TimeBasedOneTimePasswordGenerator(Duration.ZERO));
+        assertThrows(IllegalArgumentException.class, () -> new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(-1)));
+        assertThrows(IllegalArgumentException.class, () -> new TimeBasedOneTimePasswordGenerator(Duration.ofNanos(1)));
+    }
 
     @Test
     void getPasswordLength() {


### PR DESCRIPTION
This change standardizes test names, makes some tests slightly more succinct, and adds a tiny bit of missing input validation for HOTP time steps.